### PR TITLE
Changing output format to true heading.

### DIFF
--- a/boatd-opencpn
+++ b/boatd-opencpn
@@ -36,7 +36,7 @@ def degrees_to_nmea(input_degrees):
 
 def hdm(heading):
     '''Return a HDM nmea sentance from a given heading'''
-    line = 'GPHDT,{0:.3},T'.format(heading)
+    line = 'HCHDT,{0:.3},T'.format(heading)
     return nmea_line(line)
 
 def gga(latitude, longitude, utc_datetime):

--- a/boatd-opencpn
+++ b/boatd-opencpn
@@ -36,7 +36,7 @@ def degrees_to_nmea(input_degrees):
 
 def hdm(heading):
     '''Return a HDM nmea sentance from a given heading'''
-    line = 'GPHDM,{0:.3},M'.format(heading)
+    line = 'GPHDT,{0:.3},T'.format(heading)
     return nmea_line(line)
 
 def gga(latitude, longitude, utc_datetime):


### PR DESCRIPTION
OpenCPN doesn't render the magnetic heading on screen but it does show true headings.